### PR TITLE
Fix charset for base64 encoded content

### DIFF
--- a/envelope/envelope.py
+++ b/envelope/envelope.py
@@ -1280,6 +1280,7 @@ class Envelope:
                 # rather than plain text. Which could cause a transferring SMTP server to include line breaks and spaces
                 # that might break up DKIM.
                 msg_text.set_content(t.encode("utf-8"), maintype="text", subtype=mime)  # text as bytes
+                msg_text.set_param("charset", "utf-8", replace=True)
             else:
                 msg_text.set_content(t, subtype=mime)  # text as string
         else:
@@ -1298,7 +1299,13 @@ class Envelope:
                     # passing bytes to EmailMessage makes its ContentManager to transfer it via base64 or quoted-printable
                     # rather than plain text. Which could cause a transferring SMTP server to include line breaks and spaces
                     # that might break up DKIM.
-                    msg_text.add_alternative(html.encode("utf-8"), maintype="text", subtype='html')  # `html` as bytes
+                    
+                    # create an alternative message part and set utf-8 encoding explicitly
+                    alt_msg = EmailMessage()
+                    alt_msg.set_content(html.encode("utf-8"), maintype="text", subtype="html")  # `html` as bytes
+                    alt_msg.set_param("charset", "utf-8", replace=True)
+                    msg_text.make_alternative()
+                    msg_text.attach(alt_msg)
                 else:
                     msg_text.add_alternative(html, subtype='html')  # `html` as string
             except (ValueError, TypeError):

--- a/tests.py
+++ b/tests.py
@@ -127,14 +127,16 @@ class TestEnvelope(TestAbstract):
 
     def test_1000_split(self):
         self.check_lines(Envelope().message("short text").subject("my subject").send(False),
-                         ('Content-Transfer-Encoding: 7bit',
+                         ('Content-Type: text/plain; charset="utf-8"',
+                          'Content-Transfer-Encoding: 7bit',
                           "Subject: my subject",
                           "short text"), 10)
 
         # this should be no more 7bit but base64 (or quoted-printable which is however not guaranteed)
         e = Envelope().message("Longer than thousand chars. " * 1000).subject("my subject").send(False)
         self.check_lines(e,
-                         ("Content-Transfer-Encoding: base64",
+                         ('Content-Type: text/plain; charset="utf-8"',
+                          "Content-Transfer-Encoding: base64",
                           "Subject: my subject",), 100,
                          not_in=('Content-Transfer-Encoding: 7bit',)
                          )
@@ -150,14 +152,19 @@ class TestEnvelope(TestAbstract):
         # 7bit both plain and html
         self.check_lines(e.send(False),
                          ("Subject: my subject",
+                          'Content-Type: text/plain; charset="utf-8"',
                           'Content-Transfer-Encoding: 7bit',
                           "short text",
+                          'Content-Type: text/html; charset="utf-8"',
+                          'Content-Transfer-Encoding: 7bit',
                           "<b>html</b>"), 10)
 
         # 7bit html, base64 plain
         self.check_lines(e.copy().message("Longer than thousand chars. " * 1000).send(False),
                          ("Subject: my subject",
+                          'Content-Type: text/plain; charset="utf-8"',
                           "Content-Transfer-Encoding: base64",
+                          'Content-Type: text/html; charset="utf-8"',
                           'Content-Transfer-Encoding: 7bit',
                           "<b>html</b>"
                           ), 100,
@@ -167,8 +174,10 @@ class TestEnvelope(TestAbstract):
         # 7bit plain, base64 html
         self.check_lines(e.copy().message("Longer than thousand chars. " * 1000, alternative="html").send(False),
                          ("Subject: my subject",
+                          'Content-Type: text/plain; charset="utf-8"',
                           'Content-Transfer-Encoding: 7bit',
                           'short text',
+                          'Content-Type: text/html; charset="utf-8"',
                           "Content-Transfer-Encoding: base64",
                           ), 100,
                          not_in="<b>html</b>"
@@ -178,7 +187,9 @@ class TestEnvelope(TestAbstract):
         self.check_lines(e.copy().message("Longer than thousand chars. " * 1000, alternative="html")
                          .message("Longer than thousand chars. " * 1000).send(False),
                          ("Subject: my subject",
+                          'Content-Type: text/plain; charset="utf-8"',
                           "Content-Transfer-Encoding: base64",
+                          'Content-Type: text/html; charset="utf-8"',
                           "Content-Transfer-Encoding: base64",
                           ), 100,
                          not_in=('Content-Transfer-Encoding: 7bit',


### PR DESCRIPTION
As explained in the comments of the source code, the ContentManager will transfer a bytes encoded string as base64 encoded content. By default it doesn't take the original utf-8 encoding into account and therefore won't add the correct email `charset` header. This results in special characters being displayed wrong in most email clients.

This patch sets the correct utf-8 encoding in the described cases.