### PR TITLE
Update envelope.py

### DIFF
--- a/envelope/envelope.py
+++ b/envelope/envelope.py
@@ -886,8 +886,7 @@ class Envelope:
         if self._processed:
             raise RuntimeError("Cannot call .send() after .sign()/.encrypt()."
                                " You probably wanted to use .signature()/.encryption() instead.")
-        self._start(sign=sign, encrypt=encrypt, send=send)
-        return self
+        return self._start(sign=sign, encrypt=encrypt, send=send)
 
     def _prepare_from(self):
         """ Prepare private variables. Resolve "from" and "sender" headers.


### PR DESCRIPTION
Fixed error in send method: Return value did not match docstring: "To check e-mail was successfully sent, cast the returned object to bool."

With `return self` the Envelope object is always returned and casted to bool always true. There is no possibility to check, if the mail was send succesfully.

Imho a better implementation would be an option to the send method: send(raises=True), which causes the function to raise an exception, when send fails.