### PR TITLE
Use SHA-512 for signatures.

### DIFF
--- a/envelope/envelope.py
+++ b/envelope/envelope.py
@@ -1262,7 +1262,7 @@ class Envelope:
                 cert = sign
             smime.x509 = X509.load_cert_string(cert)
             if not encrypt:
-                p7 = smime.sign(content_buffer, SMIME.PKCS7_DETACHED)
+                p7 = smime.sign(content_buffer, SMIME.PKCS7_DETACHED, 'sha512')
                 content_buffer = BIO.MemoryBuffer(email)  # we have to recreate it because it was sucked out
                 smime.write(output_buffer, p7, content_buffer)
             else:


### PR DESCRIPTION
Without this, I had SHA-1 signatures being generated by default on one of my systems.

Example of unhappy Gmail:
```
The signature uses an unsupported algorithm. The digital signature is not valid. Sender info
```

Reportedly Yahoo doesn't like SHA-1 either, though I'm too lazy at the moment to verify that.

Outlook supports SHA-512 just fine in my limited testing (but defaults to SHA-1 for outgoing mail, not our problem though).

Apple Mail supports SHA-512 (tested thoroughly on my end). (And oddly accepts SHA-1.. not sure why.)

I think this is a sane default to switch to SHA-512, unless somebody can point out a popular mail client that still cannot handle SHA-2.