### PR TITLE
Sign with PyCA library

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist
 envelope.egg-info
 __pycache__
+.vscode

--- a/envelope/envelope.py
+++ b/envelope/envelope.py
@@ -1284,7 +1284,7 @@ class Envelope:
             cb = (lambda x: bytes(self._passphrase, 'ascii')) if self._passphrase \
                 else (lambda x: bytes(getpass(), 'ascii'))
             try:
- #
+
                 key = load_pem_private_key(sign, password=None)
                 cert = load_pem_x509_certificate(self._cert)
                 print(f'key: {type(key)}, sign: {type(sign)}')
@@ -1300,6 +1300,17 @@ class Envelope:
                 ).sign(
                     Encoding.SMIME, [pkcs7.PKCS7Options.DetachedSignature]
                 )
+            else:
+                output = pkcs7.PKCS7SignatureBuilder().set_data(
+                    email
+                ).add_signer(
+                    cert, key, hashes.SHA512(), rsa_padding=padding.PKCS1v15() 
+                ).sign(
+                    Encoding.SMIME, []
+                )
+
+        if encrypt:
+            print('Encrypt')
 
         return output
 


### PR DESCRIPTION
WIP solution for M2Crypto substitution by PyCA cryptography. So far only singing works with following keys:

- tests/smime/cert.pem
- tests/smime/key.pem