### PR TITLE
Experimental

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 dist
 envelope.egg-info
 __pycache__
+.vscode

--- a/envelope/envelope.py
+++ b/envelope/envelope.py
@@ -1266,7 +1266,7 @@ class Envelope:
             try:
                 # from M2Crypto import BIO, SMIME, X509, EVP  # we save up to 30 - 120 ms to load it here ; smazat
                 from cryptography.hazmat.primitives.serialization import load_pem_private_key, pkcs7, Encoding
-                from cryptography.hazmat.primitives.asymmetric import padding
+                from cryptography.hazmat.primitives.asymmetric import padding, rsa
                 from cryptography.hazmat.primitives import hashes, serialization
                 from cryptography.x509 import load_pem_x509_certificate
                 from cryptography.exceptions import UnsupportedAlgorithm
@@ -1275,149 +1275,242 @@ class Envelope:
                 BIO = SMIME = X509 = EVP = None
                 raise ImportError(smime_import_error)
 
-        if sign:
+        
+        # passphrase has to be bytes
+        if (self._passphrase is not None):
+            self._passphrase = self._passphrase.encode('utf-8')    
 
-            # Since s.load_key shall not accept file contents, we have to set the variables manually
+        if sign is not None:
             sign = assure_fetched(sign, bytes)
 
-            # XX remove getpass conversion to bytes callback when https://gitlab.com/m2crypto/m2crypto/issues/260 is resolved
-            cb = (lambda x: bytes(self._passphrase, 'ascii')) if self._passphrase \
-                else (lambda x: bytes(getpass(), 'ascii'))
+        if sign and not encrypt:
 
-            # passphrase has to be bytes
-            if (self._passphrase is not None):
-                self._passphrase = self._passphrase.encode('utf-8')    
-            
-            key = None
+            # get sender's cert
+            # cert and private key can be one file
+
+            # if certfile is not provided, sign has to have both private key and certificate
+            # cert is not in sign (--sign_path file), it is cert.pem
+            if self._cert:
+                cert = self._cert
+            else:
+                # certificate is in sign (--sign_path file), it is key-cert-together.pem
+                cert = sign
 
             try:
-                key = load_pem_private_key(sign, password=self._passphrase)
-
+                cert = load_pem_x509_certificate(cert)
             except ValueError as e:
-                # raise ValueError(f"Error loading the private key: {str(e)}")
-                print(ValueError(f"Error loading the private key: {str(e)}"))
-            except TypeError as e:
-                # raise TypeError(f"Type error when loading the private key: {str(e)}")
-                print(TypeError(f"Type error when loading the private key: {str(e)}"))
-            except UnsupportedAlgorithm as e:
-                # raise UnsupportedAlgorithm(f"Unsupported algorithm in the private key: {str(e)}")
-                print(UnsupportedAlgorithm(f"Unsupported algorithm in the private key: {str(e)}"))
+                print(f"Certificate not found: {e}")
 
-            if key is None:
-                try:
-                    key = load_pem_x509_certificate(sign)
-                except Exception as e:
-                    print(e)
+            # get senders private key for signing
+            try:
+                # sign file has certificate
+                key = load_pem_private_key(sign, password=self._passphrase)
+            except ValueError as e:
+                print(f"Error loading private key: {e}")
+            except TypeError as t:
+                print(f"Password not needed")
 
-            if self._cert:
-                cert = load_pem_x509_certificate(self._cert)
-            else:
-                cert = load_pem_x509_certificate(sign)
+            options = [pkcs7.PKCS7Options.DetachedSignature]
 
-            # Attached / detached signature option, keep empty for attached
-            pkcs7Options = []
-
-            if not encrypt:
-                pkcs7Options.append(pkcs7.PKCS7Options.DetachedSignature)
-
-            output = pkcs7.PKCS7SignatureBuilder().set_data(
+            signed_email = pkcs7.PKCS7SignatureBuilder().set_data(
                 email
             ).add_signer(
-                cert, key, hashes.SHA512(), rsa_padding=padding.PKCS1v15() 
+                cert, key, hashes.SHA256()
             ).sign(
-                Encoding.SMIME, pkcs7Options
+                serialization.Encoding.SMIME, options
             )
 
-        if encrypt:
-            from cryptography.hazmat.primitives.serialization import pkcs7  
+            return signed_email
 
-            # Get the private/public key pair and certificate
-            # private_key_pem, cert_pem = self.split_pem(encrypt[0])
 
-            # if private_key_pem:
-            #     try:
-            #         key = load_pem_private_key(private_key_pem, password=self._passphrase)
-            #     except TypeError:
-            #         raise TypeError("Ivalid key")
-            # else:
-            #     key = load_pem_private_key(self._encrypt[0], password=self._passphrase)
+        if sign and encrypt:
+            # TODO: check if sign is object or only true, find the private key somewhere else
 
-            # if cert_pem:
-            #     try:
-            #         cert = load_pem_x509_certificate(cert_pem, default_backend())
-            #         public_key = cert.public_key()
-            #     except TypeError:
-            #         raise TypeError("Ivalid cert")
-            # else:
-            #     public_key = key.public_key()
+
+            print("Sign and encrypt")
 
             if self._cert:
-                cert = load_pem_x509_certificate(self._cert)
+                sender_cert = self._cert
             else:
-                cert = load_pem_x509_certificate(encrypt[0])
+                # certificate is in sign (--sign_path file), it is key-cert-together.pem
+                sender_cert = sign
 
-            output = pkcs7.PKCS7EnvelopeBuilder().set_data(
+            try:
+                sender_cert = load_pem_x509_certificate(sender_cert)
+            except ValueError as e:
+                print(f"Certificate not found: {e}")
+
+            # get senders private key for signing
+            try:
+                # sign file has certificate
+                sender_key = load_pem_private_key(sign, password=self._passphrase)
+            except ValueError as e:
+                print(f"Error loading private key: {e}")
+            except TypeError as t:
+                # TODO: do something more usefull
+                print(f"Password not needed")
+
+            # sign the message first
+            signature_builder = pkcs7.PKCS7SignatureBuilder().set_data(email)
+            signature_builder = signature_builder.add_signer(sender_cert, sender_key, hash_algorithm=hashes.SHA256())
+            signed_email = signature_builder.sign(serialization.Encoding.SMIME, [pkcs7.PKCS7Options.DetachedSignature])
+
+            # get recipent's certificate for encryption
+            if self._cert:
+                pubkey = self._cert
+            else:
+                pubkey = encrypt[0]
+
+            try:
+                pubkey = load_pem_x509_certificate(pubkey)
+            except ValueError as e:
+                raise ValueError("failed to load certificate from file")
+
+            # encrypt signed email with recipient's cert
+            envelope_builder = pkcs7.PKCS7EnvelopeBuilder().set_data(signed_email)
+            envelope_builder = envelope_builder.add_recipient(pubkey)
+
+            options = [pkcs7.PKCS7Options.Text]
+            encrypted_email = envelope_builder.encrypt(serialization.Encoding.SMIME, options)
+            return encrypted_email
+
+
+        if not sign and encrypt:
+            # get recipients public key for encrypting
+            # the public key is part of x509 certificate of the recipient
+
+            print("Only encrypt")
+
+            if self._cert:
+                pubkey = self._cert
+            else:
+                pubkey = encrypt[0]
+
+            try:
+                pubkey = load_pem_x509_certificate(pubkey)
+            except ValueError as e:
+                raise ValueError("failed to load certificate from file")
+
+            options = [pkcs7.PKCS7Options.Text]
+            encrypted_email = pkcs7.PKCS7EnvelopeBuilder().set_data(
                 email
             ).add_recipient(
-                cert
+                pubkey
             ).encrypt(
-                serialization.Encoding.SMIME, [pkcs7.PKCS7Options.Text]
+                serialization.Encoding.SMIME, options
             )
-            if sign:
-                pass
+
+            return encrypted_email
+
+
+        # if sign:
+
+        #     # Since s.load_key shall not accept file contents, we have to set the variables manually
+        #     sign = assure_fetched(sign, bytes)
+
+        #     # XX remove getpass conversion to bytes callback when https://gitlab.com/m2crypto/m2crypto/issues/260 is resolved
+        #     cb = (lambda x: bytes(self._passphrase, 'ascii')) if self._passphrase \
+        #         else (lambda x: bytes(getpass(), 'ascii'))
+
+        #     # passphrase has to be bytes
+        #     if (self._passphrase is not None):
+        #         self._passphrase = self._passphrase.encode('utf-8')    
+            
+        #     key = None
+
+        #     try:
+        #         key = load_pem_private_key(sign, password=self._passphrase)
+
+        #     except ValueError as e:
+        #         # raise ValueError(f"Error loading the private key: {str(e)}")
+        #         print(ValueError(f"Error loading the private key: {str(e)}"))
+        #     except TypeError as e:
+        #         # raise TypeError(f"Type error when loading the private key: {str(e)}")
+        #         print(TypeError(f"Type error when loading the private key: {str(e)}"))
+        #     except UnsupportedAlgorithm as e:
+        #         # raise UnsupportedAlgorithm(f"Unsupported algorithm in the private key: {str(e)}")
+        #         print(UnsupportedAlgorithm(f"Unsupported algorithm in the private key: {str(e)}"))
+
+        #     if key is None:
+        #         try:
+        #             key = load_pem_x509_certificate(sign)
+        #         except Exception as e:
+        #             print(e)
+
+        #     if self._cert:
+        #         cert = load_pem_x509_certificate(self._cert)
+        #     else:
+        #         cert = load_pem_x509_certificate(sign)
+
+        #     # Attached / detached signature option, keep empty for attached
+        #     pkcs7Options = []
+
+        #     if not encrypt:
+        #         pkcs7Options.append(pkcs7.PKCS7Options.DetachedSignature)
+
+        #     output = pkcs7.PKCS7SignatureBuilder().set_data(
+        #         email
+        #     ).add_signer(
+        #         cert, key, hashes.SHA512(), rsa_padding=padding.PKCS1v15() 
+        #     ).sign(
+        #         Encoding.SMIME, pkcs7Options
+        #     )
+
+        # if encrypt:
+        #     from cryptography.hazmat.primitives.serialization import pkcs7  
+
+        #     # Get the private/public key pair and certificate
+        #     # private_key_pem, cert_pem = self.split_pem(encrypt[0])
+
+        #     # if private_key_pem:
+        #     #     try:
+        #     #         key = load_pem_private_key(private_key_pem, password=self._passphrase)
+        #     #     except TypeError:
+        #     #         raise TypeError("Ivalid key")
+        #     # else:
+        #     #     key = load_pem_private_key(self._encrypt[0], password=self._passphrase)
+
+        #     # if cert_pem:
+        #     #     try:
+        #     #         cert = load_pem_x509_certificate(cert_pem, default_backend())
+        #     #         public_key = cert.public_key()
+        #     #     except TypeError:
+        #     #         raise TypeError("Ivalid cert")
+        #     # else:
+        #     #     public_key = key.public_key()
+
+        #     if self._cert:
+        #         cert = load_pem_x509_certificate(self._cert)
+        #     else:
+        #         cert = load_pem_x509_certificate(encrypt[0])
+
+        #     output = pkcs7.PKCS7EnvelopeBuilder().set_data(
+        #         email
+        #     ).add_recipient(
+        #         cert
+        #     ).encrypt(
+        #         serialization.Encoding.SMIME, [pkcs7.PKCS7Options.Text]
+        #     )
+        #     if sign:
+        #         pass
 
             
-            # [sk.push(X509.load_cert_string(e)) for e in assure_list(encrypt)]
-            # print()
-            # for s in sk:
-            #     print(s)
-            # print()
+        #     # [sk.push(X509.load_cert_string(e)) for e in assure_list(encrypt)]
+        #     # print()
+        #     # for s in sk:
+        #     #     print(s)
+        #     # print()
 
-            # XX certificates might be loaded from a directory by from, to, sender:
-            # X509.load_cert_string(assure_fetched(e, bytes)).get_subject() ->
-            # 'C=CZ, ST=State, L=City, O=Organisation, OU=Unit, CN=my-name/emailAddress=email@example.com'
-            # X509.load_cert_string can take 7 µs, so the directory should be cached somewhere.
+        #     # XX certificates might be loaded from a directory by from, to, sender:
+        #     # X509.load_cert_string(assure_fetched(e, bytes)).get_subject() ->
+        #     # 'C=CZ, ST=State, L=City, O=Organisation, OU=Unit, CN=my-name/emailAddress=email@example.com'
+        #     # X509.load_cert_string can take 7 µs, so the directory should be cached somewhere.
 
-            # # Encrypt the buffer.
-            # p7 = smime.encrypt(content_buffer)
-            # smime.write(output_buffer, p7)
+        #     # # Encrypt the buffer.
+        #     # p7 = smime.encrypt(content_buffer)
+        #     # smime.write(output_buffer, p7)
 
-
-
-        return output
-
-    def split_pem(self, pem_data):
-        from cryptography.x509 import load_pem_x509_certificate
-        key_start = b"-----BEGIN PRIVATE KEY-----"
-        key_end = b"-----END PRIVATE KEY-----"
-        cert_start = b"-----BEGIN CERTIFICATE-----"
-        cert_end = b"-----END CERTIFICATE-----"
-
-        try:
-            key_start_index = pem_data.index(key_start)
-            key_end_index = pem_data.index(key_end)
-
-            if key_start_index != -1 and key_end_index != -1:
-                private_key = pem_data[key_start_index:key_end_index + len(key_end)]
-            else:
-                private_key = None
-        except ValueError:
-            private_key = None
-
-        try:
-            cert_start_index = pem_data.index(cert_start)
-            cert_end_index = pem_data.index(cert_end)
-
-            if cert_start_index != -1 and cert_end_index != -1:
-                cert = pem_data[cert_start_index:cert_end_index + len(cert_end)]
-            elif self._cert:
-                cert = load_pem_x509_certificate(self._cert)
-            else:
-                cert = None
-        except ValueError:
-            cert = None
-
-        return private_key, cert
+        # return output
 
 
     def _compose_gpg_signed(self, email, text, micalg=None):

--- a/envelope/envelope.py
+++ b/envelope/envelope.py
@@ -1284,7 +1284,7 @@ class Envelope:
             cb = (lambda x: bytes(self._passphrase, 'ascii')) if self._passphrase \
                 else (lambda x: bytes(getpass(), 'ascii'))
             try:
- #
+
                 key = load_pem_private_key(sign, password=None)
                 cert = load_pem_x509_certificate(self._cert)
                 print(f'key: {type(key)}, sign: {type(sign)}')
@@ -1300,6 +1300,17 @@ class Envelope:
                 ).sign(
                     Encoding.SMIME, [pkcs7.PKCS7Options.DetachedSignature]
                 )
+            else:
+                output = pkcs7.PKCS7SignatureBuilder().set_data(
+                    email
+                ).add_signer(
+                    cert, key, hashes.SHA512(), rsa_padding=padding.PKCS1v15() 
+                ).sign(
+                    Encoding.SMIME, []
+                )
+
+        if encrypt:
+            print('Encrypt')
 
         return output
 

--- a/envelope/envelope.py
+++ b/envelope/envelope.py
@@ -1280,8 +1280,6 @@ class Envelope:
             # Since s.load_key shall not accept file contents, we have to set the variables manually
             sign = assure_fetched(sign, bytes)
 
-            # from M2Crypto import BIO, SMIME, X509, EVP
-
             # XX remove getpass conversion to bytes callback when https://gitlab.com/m2crypto/m2crypto/issues/260 is resolved
             cb = (lambda x: bytes(self._passphrase, 'ascii')) if self._passphrase \
                 else (lambda x: bytes(getpass(), 'ascii'))
@@ -1289,21 +1287,32 @@ class Envelope:
             # passphrase has to be bytes
             if (self._passphrase is not None):
                 self._passphrase = self._passphrase.encode('utf-8')    
+            
+            key = None
 
             try:
-
                 key = load_pem_private_key(sign, password=self._passphrase)
-                if self._cert:
-                    cert = load_pem_x509_certificate(self._cert)
-                else:
-                    cert = load_pem_x509_certificate(sign)
 
             except ValueError as e:
-                raise ValueError(f"Error loading the private key: {str(e)}")
+                # raise ValueError(f"Error loading the private key: {str(e)}")
+                print(ValueError(f"Error loading the private key: {str(e)}"))
             except TypeError as e:
-                raise TypeError(f"Type error when loading the private key: {str(e)}")
+                # raise TypeError(f"Type error when loading the private key: {str(e)}")
+                print(TypeError(f"Type error when loading the private key: {str(e)}"))
             except UnsupportedAlgorithm as e:
-                raise UnsupportedAlgorithm(f"Unsupported algorithm in the private key: {str(e)}")
+                # raise UnsupportedAlgorithm(f"Unsupported algorithm in the private key: {str(e)}")
+                print(UnsupportedAlgorithm(f"Unsupported algorithm in the private key: {str(e)}"))
+
+            if key is None:
+                try:
+                    key = load_pem_x509_certificate(sign)
+                except Exception as e:
+                    print(e)
+
+            if self._cert:
+                cert = load_pem_x509_certificate(self._cert)
+            else:
+                cert = load_pem_x509_certificate(sign)
 
             # Attached / detached signature option, keep empty for attached
             pkcs7Options = []

--- a/envelope/envelope.py
+++ b/envelope/envelope.py
@@ -1376,6 +1376,29 @@ class Envelope:
             encrypted_email = encrypted_email.add_recipient(recip)
 
         encrypted_email = encrypted_email.encrypt(serialization.Encoding.SMIME, options)
+
+        # from cryptography.hazmat.primitives.serialization import load_pem_private_key
+        # from cryptography.hazmat.primitives import hashes
+        # from cryptography.hazmat.primitives.asymmetric import padding
+
+        # with open('tests/smime/key-cert-together.pem', 'rb') as keycert_file:
+        #     content = keycert_file.read()
+        #     c = load_pem_x509_certificate(content)
+        #     k = load_pem_private_key(content, password=self._passphrase)
+
+        # plaintext = k.decrypt(
+        #     encrypted_email,
+        #     padding=padding.OAEP(
+        #         mgf=padding.MGF1(
+        #             algorithm=hashes.SHA256()
+        #         ),
+        #         algorithm=hashes.SHA256(),
+        #         label=None
+        #     )
+        # )
+        # print(plaintext)
+
+
         return encrypted_email
 
 

--- a/test_.py
+++ b/test_.py
@@ -46,7 +46,7 @@ class TestAbstract(TestCase):
     invalid_headers = Path("tests/eml/invalid-headers.eml")
 
     def check_lines(self, o, lines: Union[str, Tuple[str, ...]] = (), longer: Union[int, Tuple[int, int]] = None,
-                    debug=False, not_in: Union[str, Tuple[str, ...]] = (), raises=(), result=None):
+                    debug=True, not_in: Union[str, Tuple[str, ...]] = (), raises=(), result=None):
         """ Converts Envelope objects to str and asserts that lines are present.
         :type lines: Assert in. These line/s must be found in the given order.
         :type not_in: Assert not in.
@@ -94,7 +94,7 @@ class TestAbstract(TestCase):
 
     cmd = "python3", "-m", "envelope"
 
-    def bash(self, *cmd, file: Path = None, piped=None, envelope=True, env=None, debug=False, decode=True):
+    def bash(self, *cmd, file: Path = None, piped=None, envelope=True, env=None, debug=True, decode=True):
         """
 
         :param cmd: Any number of commands.
@@ -360,7 +360,8 @@ class TestSmime(TestAbstract):
                           "Reply-To: test-reply@example.com",
                           MESSAGE,
                           'Content-Disposition: attachment; filename="smime.p7s"',
-                          "MIIEtwYJKoZIhvcNAQcCoIIEqDCCBKQCAQExDzANBglghkgBZQMEAgMFADALBgkq",), 10)
+                        #   "MIIEtwYJKoZIhvcNAQcCoIIEqDCCBKQCAQExDzANBglghkgBZQMEAgMFADALBgkq",), 10)
+                          "MIIEcwYJKoZIhvcNAQcCoIIEZDCCBGACAQExDzANBglghkgBZQMEAgMFADALBgkq",), 10)
 
     def test_smime_key_cert_together(self):
         self.check_lines(Envelope(MESSAGE)
@@ -377,6 +378,7 @@ class TestSmime(TestAbstract):
                          .sign(),
                          ('Content-Disposition: attachment; filename="smime.p7s"',
                           "MIIEtwYJKoZIhvcNAQcCoIIEqDCCBKQCAQExDzANBglghkgBZQMEAgMFADALBgkq"), 10)
+                        #   "MIIEcwYJKoZIhvcNAQcCoIIEZDCCBGACAQExDzANBglghkgBZQMEAgMFADALBgkq"
 
     def test_smime_encrypt(self):
         # Message will look that way:
@@ -426,7 +428,8 @@ class TestSmime(TestAbstract):
                           "Reply-To: test-reply@example.com",
                           MESSAGE,
                           'Content-Disposition: attachment; filename="smime.p7s"',
-                          "MIIEtwYJKoZIhvcNAQcCoIIEqDCCBKQCAQExDzANBglghkgBZQMEAgMFADALBgkq",), 10)
+                        #   "MIIEtwYJKoZIhvcNAQcCoIIEqDCCBKQCAQExDzANBglghkgBZQMEAgMFADALBgkq",), 10)
+                          "MIIEcwYJKoZIhvcNAQcCoIIEZDCCBGACAQExDzANBglghkgBZQMEAgMFADALBgkq",), 10)
         self.check_lines(Envelope(MESSAGE)
                          .subject("my subject")
                          .reply_to("test-reply@example.com")

--- a/test_.py
+++ b/test_.py
@@ -360,8 +360,8 @@ class TestSmime(TestAbstract):
                           "Reply-To: test-reply@example.com",
                           MESSAGE,
                           'Content-Disposition: attachment; filename="smime.p7s"',
-                          "MIIEtwYJKoZIhvcNAQcCoIIEqDCCBKQCAQExDzANBglghkgBZQMEAgMFADALBgkq",), 10)
-                        #   "MIIEcwYJKoZIhvcNAQcCoIIEZDCCBGACAQExDzANBglghkgBZQMEAgMFADALBgkq",), 10)
+                        #   "MIIEtwYJKoZIhvcNAQcCoIIEqDCCBKQCAQExDzANBglghkgBZQMEAgMFADALBgkq",), 10) # original
+                          "MIIEUwYJKoZIhvcNAQcCoIIERDCCBEACAQExDzANBglghkgBZQMEAgEFADALBgkq",), 10)
 
     def test_smime_key_cert_together(self):
         self.check_lines(Envelope(MESSAGE)
@@ -369,7 +369,8 @@ class TestSmime(TestAbstract):
                          .signature(self.key_cert_together)
                          .sign(),
                          ('Content-Disposition: attachment; filename="smime.p7s"',
-                          "MIIEggYJKoZIhvcNAQcCoIIEczCCBG8CAQExCzAJBgUrDgMCGgUAMAsGCSqGSIb3"))
+                        #   "MIIEggYJKoZIhvcNAQcCoIIEczCCBG8CAQExCzAJBgUrDgMCGgUAMAsGCSqGSIb3")) # original
+                          "MIIEUwYJKoZIhvcNAQcCoIIERDCCBEACAQExDzANBglghkgBZQMEAgEFADALBgkq"))
 
     def test_smime_key_cert_together_passphrase(self):
         self.check_lines(Envelope(MESSAGE)
@@ -377,8 +378,9 @@ class TestSmime(TestAbstract):
                          .signature(Path("tests/smime/key-cert-together-passphrase.pem"), passphrase=GPG_PASSPHRASE)
                          .sign(),
                          ('Content-Disposition: attachment; filename="smime.p7s"',
-                          "MIIEtwYJKoZIhvcNAQcCoIIEqDCCBKQCAQExDzANBglghkgBZQMEAgMFADALBgkq"), 10)
-                        #   "MIIEcwYJKoZIhvcNAQcCoIIEZDCCBGACAQExDzANBglghkgBZQMEAgMFADALBgkq"), 10)
+                        #   "MIIEtwYJKoZIhvcNAQcCoIIEqDCCBKQCAQExDzANBglghkgBZQMEAgMFADALBgkq"), 10) # original
+                          "MIIEUwYJKoZIhvcNAQcCoIIERDCCBEACAQExDzANBglghkgBZQMEAgEFADALBgkq"), 10)
+                        
 
     def test_smime_encrypt(self):
         # Message will look that way:
@@ -428,8 +430,8 @@ class TestSmime(TestAbstract):
                           "Reply-To: test-reply@example.com",
                           MESSAGE,
                           'Content-Disposition: attachment; filename="smime.p7s"',
-                        #   "MIIEtwYJKoZIhvcNAQcCoIIEqDCCBKQCAQExDzANBglghkgBZQMEAgMFADALBgkq",), 10)
-                          "MIIEcwYJKoZIhvcNAQcCoIIEZDCCBGACAQExDzANBglghkgBZQMEAgMFADALBgkq",), 10)
+                        #   "MIIEcwYJKoZIhvcNAQcCoIIEZDCCBGACAQExDzANBglghkgBZQMEAgMFADALBgkq",), 10) # orifinal
+                          "MIIEUwYJKoZIhvcNAQcCoIIERDCCBEACAQExDzANBglghkgBZQMEAgEFADALBgkq",), 10)
         self.check_lines(Envelope(MESSAGE)
                          .subject("my subject")
                          .reply_to("test-reply@example.com")

--- a/test_.py
+++ b/test_.py
@@ -360,8 +360,8 @@ class TestSmime(TestAbstract):
                           "Reply-To: test-reply@example.com",
                           MESSAGE,
                           'Content-Disposition: attachment; filename="smime.p7s"',
-                        #   "MIIEtwYJKoZIhvcNAQcCoIIEqDCCBKQCAQExDzANBglghkgBZQMEAgMFADALBgkq",), 10)
-                          "MIIEcwYJKoZIhvcNAQcCoIIEZDCCBGACAQExDzANBglghkgBZQMEAgMFADALBgkq",), 10)
+                          "MIIEtwYJKoZIhvcNAQcCoIIEqDCCBKQCAQExDzANBglghkgBZQMEAgMFADALBgkq",), 10)
+                        #   "MIIEcwYJKoZIhvcNAQcCoIIEZDCCBGACAQExDzANBglghkgBZQMEAgMFADALBgkq",), 10)
 
     def test_smime_key_cert_together(self):
         self.check_lines(Envelope(MESSAGE)

--- a/test_.py
+++ b/test_.py
@@ -378,13 +378,13 @@ class TestSmime(TestAbstract):
                          .sign(),
                          ('Content-Disposition: attachment; filename="smime.p7s"',
                           "MIIEtwYJKoZIhvcNAQcCoIIEqDCCBKQCAQExDzANBglghkgBZQMEAgMFADALBgkq"), 10)
-                        #   "MIIEcwYJKoZIhvcNAQcCoIIEZDCCBGACAQExDzANBglghkgBZQMEAgMFADALBgkq"
+                        #   "MIIEcwYJKoZIhvcNAQcCoIIEZDCCBGACAQExDzANBglghkgBZQMEAgMFADALBgkq"), 10)
 
     def test_smime_encrypt(self):
         # Message will look that way:
         # MIME-Version: 1.0
         # Content-Disposition: attachment; filename="smime.p7m"
-        # Content-Type: application/x-pkcs7-mime; smime-type=enveloped-data; name="smime.p7m"
+        # Content-Type: application/x-pkcs7-mime; smime-type=enveloped-data; name="smime.p7m" # note: x- is deprecated and current standard recomends using quotes around smime-type="enveloped-data", without is also accepted
         # Content-Transfer-Encoding: base64
         #
         # MIIBPQYJKoZIhvcNAQcDoIIBLjCCASoCAQAxgfcwgfQCAQAwXTBFMQswCQYDVQQG
@@ -401,7 +401,7 @@ class TestSmime(TestAbstract):
                          .encryption(Path(self.smime_cert))
                          .send(False),
                          (
-                             'Content-Type: application/x-pkcs7-mime; smime-type=enveloped-data; name="smime.p7m"',
+                             'Content-Type: application/pkcs7-mime; smime-type="enveloped-data"; name="smime.p7m"',
                              "Subject: my message",
                              "Reply-To: test-reply@example.com",
                              "Z2l0cyBQdHkgTHRkAhROmwkIH63oarp3NpQqFoKTy1Q3tTANBgkqhkiG9w0BAQEF",
@@ -436,7 +436,7 @@ class TestSmime(TestAbstract):
                          .encryption(self.key_cert_together)
                          .send(False),
                          (
-                             'Content-Type: application/x-pkcs7-mime; smime-type=enveloped-data; name="smime.p7m"',
+                             'Content-Type: application/pkcs7-mime; smime-type="enveloped-data"; name="smime.p7m"',
                              "Subject: my subject",
                              "Reply-To: test-reply@example.com",
                              "Z2l0cyBQdHkgTHRkAhROmwkIH63oarp3NpQqFoKTy1Q3tTANBgkqhkiG9w0BAQEF",
@@ -510,10 +510,10 @@ class TestSmime(TestAbstract):
     #     e = Envelope.load(path="tests/eml/smime_sign.eml", key=self.smime_key, cert=self.smime_cert)
     #     self.assertEqual(MESSAGE, e.message())
 
-    def test_smime_key_cert_together(self):
-        # XX verify signature
-        e=Envelope.load(path="tests/eml/smime_key_cert_together.eml", key=self.key_cert_together)
-        self.assertEqual(MESSAGE, e.message())
+    # def test_smime_key_cert_together(self):
+    #     # XX verify signature
+    #     e=Envelope.load(path="tests/eml/smime_key_cert_together.eml", key=self.key_cert_together)
+    #     self.assertEqual(MESSAGE, e.message())
 
 
 class TestGPG(TestAbstract):


### PR DESCRIPTION
_encrypt_smime_now is now split to 3 separate methods, each dealing with signing only / signing + encrypting / encrypting only cases. Expected tests values were edited to check against currently generated output. Generated emails were manually tested if they can be verified and/or encrypted and the values were taken from those emails. Fixed the issue with encrypting email for multiple recipients.

Email can be verified/decrypted using openssl cli, however tests are expecting some different type of output.
`<class 'AssertionError'> b'dumb message' != b'Content-Type: text/plain\r\n\r\ndumb message'`, similar issue is with test_smime_decrypt_attachments

